### PR TITLE
Fix Bramble Navigation practice state

### DIFF
--- a/SpeedTools/PracticeState.cs
+++ b/SpeedTools/PracticeState.cs
@@ -40,45 +40,53 @@ namespace SpeedTools
         {
             new FishState
             {
-                    pos = new Vector3(761.3f, 99.2f, 257.0f),
-                    rot = new Quaternion(0.6f, 0.1f, -0.2f, 0.8f)
+                pos = new Vector3(715.7f, -86.4f, 4220.8f),
+                rot = new Quaternion(0.3f, -0.6f, -0.3f, -0.7f)
             },
             new FishState
             {
-                    pos = new Vector3(-397.8f, -153.8f, -279.4f),
-                    rot = new Quaternion(-0.1f, -0.8f, -0.1f, 0.5f)
-            },new FishState
+                pos = new Vector3(-397.8f, -153.8f, -279.4f),
+                rot = new Quaternion(-0.1f, -0.8f, -0.1f, 0.5f)
+            },
+            new FishState
             {
-                    pos = new Vector3(406.4f, -3027.0f, 1979.6f),
-                    rot = new Quaternion(-0.2f, 0.9f, 0.4f, -0.3f)
-            },new FishState
+                pos = new Vector3(3587.3f, 267.0f, 2057.2f),
+                rot = new Quaternion(-0.2f, 0.4f, 0.0f, -0.9f)
+            },
+            new FishState
             {
-                    pos = new Vector3(666.5f, -36.2f, 48.8f),
-                    rot = new Quaternion(-0.2f, -0.8f, -0.4f, 0.3f)
-            },new FishState
+                pos = new Vector3(406.4f, -3027.0f, 1979.6f),
+                rot = new Quaternion(-0.2f, 0.9f, 0.4f, -0.3f)
+            },
+            new FishState
             {
-                    pos = new Vector3(25.0f, 2432.1f, 2024.3f),
-                    rot = new Quaternion(0.6f, -0.6f, 0.0f, -0.6f)
-            },new FishState
+                pos = new Vector3(25.0f, 2432.1f, 2024.3f),
+                rot = new Quaternion(0.6f, -0.6f, 0.0f, -0.6f)
+            },
+            new FishState
             {
-                    pos = new Vector3(4406.0f, -411.0f, 1203.4f),
-                    rot = new Quaternion(-0.3f, -0.9f, -0.4f, -0.1f)
-            },new FishState
+                pos = new Vector3(761.3f, 99.2f, 257.0f),
+                rot = new Quaternion(0.6f, 0.1f, -0.2f, 0.8f)
+            },
+            new FishState
             {
-                    pos = new Vector3(826.6f, 195.3f, 73.1f),
-                    rot = new Quaternion(0.0f, -0.8f, 0.5f, 0.3f)
-            },new FishState
+                pos = new Vector3(85.6f, -193.6f, 449.9f),
+                rot = new Quaternion(-0.2f, -0.1f, -0.9f, 0.4f)
+            },
+            new FishState
             {
-                    pos = new Vector3(85.6f, -193.6f, 449.9f),
-                    rot = new Quaternion(-0.2f, -0.1f, -0.9f, 0.4f)
-            },new FishState
+                pos = new Vector3(666.5f, -36.2f, 48.8f),
+                rot = new Quaternion(-0.2f, -0.8f, -0.4f, 0.3f)
+            },
+            new FishState
             {
-                    pos = new Vector3(715.7f, -86.4f, 4220.8f),
-                    rot = new Quaternion(0.3f, -0.6f, -0.3f, -0.7f)
-            },new FishState
+                pos = new Vector3(826.6f, 195.3f, 73.1f),
+                rot = new Quaternion(0.0f, -0.8f, 0.5f, 0.3f)
+            },
+            new FishState
             {
-                    pos = new Vector3(3587.3f, 267.0f, 2057.2f),
-                    rot = new Quaternion(-0.2f, 0.4f, 0.0f, -0.9f)
+                pos = new Vector3(4406.0f, -411.0f, 1203.4f),
+                rot = new Quaternion(-0.3f, -0.9f, -0.4f, -0.1f)
             }
         };
     }


### PR DESCRIPTION
The Bramble Navigation practice state has been broken since 1.1.14, but this fixes it just by reordering the fishStates.